### PR TITLE
minor import compatibility

### DIFF
--- a/asciiplotlib/table.py
+++ b/asciiplotlib/table.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-from collections.abc import Sequence
+from collections import Sequence
 import sys
 
 from .helpers import create_padding_tuple


### PR DESCRIPTION
Python 2 has `collections` but not `collections.abc`. 
`Sequence` works just fine there, but it's a native type, not `collections.abc.Sequence`.